### PR TITLE
Add netlify deployment button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Middleman template
 
+## Netlify deployment
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/wallin/middleman-template)
+
 ## Heroku deployment
 Don't forget to add the middleman buildpack to your app
 


### PR DESCRIPTION
I found this template while looking for already styled middleman boilerplates for a [site](http://pizza.netlify.com) I am creating.

Deploying a middleman site makes sense to Heroku because it works, but it is pricey. I added a deploy to Netlify button in addition to the Heroku mention for another option for users that use this template. 

##### Known issues

- heroku's minimum plan $7
- Netlify is free for all projects and increases to $9 for more features. There is an [opensource](https://www.netlify.com/open-source) plan available as well.

##### To-do

- nothing else is needed to make this work

##### Demo
- test the button here

[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/bdougie/middleman-startae)